### PR TITLE
Get-GPT3Completion:  Avoiding 2nd error

### DIFF
--- a/Public/Get-GPT3Completion.ps1
+++ b/Public/Get-GPT3Completion.ps1
@@ -99,7 +99,7 @@ function Get-GPT3Completion {
     if ($Raw) {
         $result
     } 
-    else {
+    elseif ($result.choices) {
         $result.choices[0].text
     }
 }


### PR DESCRIPTION
Avoiding 2nd error when GPT-3 does not return a result (Fixes #26)