### PR TITLE
Contributions: Various Items to Contribute

### DIFF
--- a/Private/CustomReadHost.ps1
+++ b/Private/CustomReadHost.ps1
@@ -1,9 +1,19 @@
-function CustomReadHost {
+function CustomRunCodeReadHost {
     $Yes = New-Object System.Management.Automation.Host.ChoiceDescription '&Yes', 'Yes, run the code'    
     $no = New-Object System.Management.Automation.Host.ChoiceDescription '&No', 'No, do not run the code'
 
     $options = [System.Management.Automation.Host.ChoiceDescription[]]($Yes, $no)
 
     $message = 'Run the code?'
+    $host.ui.PromptForChoice($null, $message, $options, 1)
+}
+
+function CustomContinueReadHost {
+    $Yes = New-Object System.Management.Automation.Host.ChoiceDescription '&Yes', 'Yes, continue on with request'
+    $no = New-Object System.Management.Automation.Host.ChoiceDescription '&No', 'No, do not continue with request'
+
+    $options = [System.Management.Automation.Host.ChoiceDescription[]]($Yes, $no)
+
+    $message = 'Continue with request?'
     $host.ui.PromptForChoice($null, $message, $options, 1)
 }

--- a/Private/Get-ModerationClassification.ps1
+++ b/Private/Get-ModerationClassification.ps1
@@ -1,0 +1,70 @@
+
+function Get-ModerationClassification {
+    [CmdletBinding()]
+    <#
+        .SYNOPSIS
+        Used to check whether content complies with OpenAI's content policy.
+        
+        .DESCRIPTION
+        This function utilizes the moderation endpoint to check whether content complies with OpenAI's content policy. If content is identified that the OpenAI policy prohibits, action can be taken. For instance, the content can be filtered. For additional information about the moderation endpoint api, refer to https://beta.openai.com/docs/api-reference/moderations. For additional information about the content policy, refer to https://beta.openai.com/docs/usage-policies/content-policy
+        
+        .PARAMETER $line
+        Default is OpenAIKey stored as an environmental variable. Otherwise, Api token is a secure string.
+
+        .PARAMETER openAiToken
+        OpenAI API Token as a secure string.  By default, $env:OpenAIKey will be utilized.
+    #>
+    param (
+        [ValidateNotNullOrEmpty()]
+        [string]$prompt,
+        [securestring]$openAiToken = (ConvertTo-SecureString -String $($env:OpenAIKey) -AsPlainText)
+    )
+
+    if($null -eq $openAiToken){
+        throw 'OpenAI API key not found. Please set $env:OpenAIKey to your OpenAI API key or pass in the key as a Secure String'
+    }
+
+    $body = @{input="$($prompt)"} | ConvertTo-Json -Compress
+
+    Write-Progress -Activity "Codex Moderations" -Status "Getting moderation results..."
+    try {
+        $moderation = Invoke-RestMethod -Uri "https://api.openai.com/v1/moderations" -ContentType 'application/json' -Authentication Bearer -Token $openAiToken -Body $body -Method Post
+    }
+    catch {
+        Write-Error $_
+        Write-Verbose -Verbose $body
+    }
+
+    if($moderation){
+
+        Write-Progress -Activity "Codex Moderation" -Status "Analyzing results from endpoint..."
+
+        if($moderation.results.flagged -eq $true){
+            $moderationModel = $moderation.model
+            $categories = $moderation.results.categories | Get-Member -MemberType NoteProperty | Select-Object -Property Name
+            $violatedCategories = $null
+            $categories | ForEach-Object{
+                $categoryName = $_.Name
+                if($null -eq $violatedCategories -and $moderation.results.categories.$($categoryName) -eq $true){
+                    $violatedCategories = $categoryName
+                }elseif($moderation.results.categories.$($categoryName) -eq $true){
+                    $violatedCategories = $violatedCategories + ", " + $categoryName
+                }
+            }
+
+            Write-Progress -Activity "Codex Moderation" -Completed
+            Write-Warning "The model, $($moderationModel), has classified the content as having violated OpenAI's content policy in the following categories: $($categories)"
+            $userInput = CustomContinueReadHost 
+            if($userInput -eq 1){
+                throw "Process has stopped."
+                Exit
+            }
+        }
+
+        Write-Progress -Activity "Codex Moderation" -Completed
+
+    }else {
+        Write-Progress -Activity "Codex Moderation" -Completed
+        Write-Warning "Content could not be validated."
+    }
+}

--- a/Private/Get-ModerationClassification.ps1
+++ b/Private/Get-ModerationClassification.ps1
@@ -8,7 +8,7 @@ function Get-ModerationClassification {
         .DESCRIPTION
         This function utilizes the moderation endpoint to check whether content complies with OpenAI's content policy. If content is identified that the OpenAI policy prohibits, action can be taken. For instance, the content can be filtered. For additional information about the moderation endpoint api, refer to https://beta.openai.com/docs/api-reference/moderations. For additional information about the content policy, refer to https://beta.openai.com/docs/usage-policies/content-policy
         
-        .PARAMETER $line
+        .PARAMETER prompt
         Default is OpenAIKey stored as an environmental variable. Otherwise, Api token is a secure string.
 
         .PARAMETER openAiToken

--- a/Private/Test-OpenAIKey.ps1
+++ b/Private/Test-OpenAIKey.ps1
@@ -1,3 +1,31 @@
+
+
 function Test-OpenAIKey {
-    -not [string]::IsNullOrEmpty($env:OpenAIKey)
+    [CmdletBinding()]
+    <#
+        .SYNOPSIS
+        Used to validate api key
+        .DESCRIPTION
+        Validates OpenAIKey
+        .PARAMETER openAiKey
+        Default is OpenAIKey stored as an environmental variable. Otherwise, Api token is a secure string.
+        .PARAMETER model
+        The OpenAI API model by which to validate token. Default is text-davinci-003.
+    #>
+    param (
+        [securestring]$openAiToken = (ConvertTo-SecureString -String $($env:OpenAIKey) -AsPlainText), 
+        [string]$model = 'text-davinci-003'
+    )
+
+    try {
+            Write-Progress -Activity "OpenAI Key" -Status "Validating..."
+            Invoke-RestMethod -Uri "https://api.openai.com/v1/models/$($model)" -Authentication Bearer -Token $openAiToken                
+            Write-Progress -Activity "OpenAI Key" -Completed
+            return $true
+    }
+    catch {
+        $statusCode = $_.Exception.Response.StatusCode.value__
+        Write-Error $statusCode
+        throw 'Failed to access OpenAI api [$statusCode]. Please check your OpenAI API key (https://beta.openai.com/account/api-keys) and Organization ID (https://beta.openai.com/account/org-settings). You may also need to set the $env:OpenAIKey environment variable to your OpenAI API key or pass in the key as a secure string.'
+    }
 }

--- a/Public/copilot.ps1
+++ b/Public/copilot.ps1
@@ -61,7 +61,7 @@ function copilot {
 
         $result | CreateBoxText
 
-        $userInput = CustomReadHost
+        $userInput = CustomRunCodeReadHost
 
         if ($userInput -eq 0) {
             $runnable = for ($idx = 1; $idx -lt $result.Count; $idx++) {


### PR DESCRIPTION
A moderation filter has been added as a new method, `Get-ModerationClassification`.  This function makes a request to the [moderation](https://beta.openai.com/docs/api-reference/moderations) endpoint to check whether the prompt being sent complies to the OpenAI's [content policy](https://beta.openai.com/docs/usage-policies/content-policy). If content is not flagged, then process continues. If content is flagged, a new `customreadhost` function requests input from the user as to whether or not the process should continue.

`Test-OpenAIKey` was updated to validate the OpenAIKey as a tokenized secure string variable on the endpoint via a get request.  

The `Get-GPT3Completion` makes use of a secure string parameter regardless of the `$env:OpenAIKey` variable or, if it is pulled in via a Secret Vault.  This provides more flexibility with security.  This is associated with the code review request in our discussion, #25. 

Finally, several `Write-Progress` cmdlets have been added that might help address items in issue #17 