### PR TITLE
On PS 6 and higher use Invoke-RestMethod with secure Token

### DIFF
--- a/PowerShellAI.psd1
+++ b/PowerShellAI.psd1
@@ -1,6 +1,6 @@
 @{
     RootModule        = 'PowerShellAI.psm1'
-    ModuleVersion     = '0.4.6'
+    ModuleVersion     = '0.4.7'
     GUID              = '081ce7b4-6e63-41ca-92a7-2bf72dbad018'
     Author            = 'Douglas Finke'
     CompanyName       = 'Doug Finke'

--- a/Private/Get-OpenAIKey.ps1
+++ b/Private/Get-OpenAIKey.ps1
@@ -1,7 +1,7 @@
 function Get-OpenAIKey {
     <#
         .SYNOPSIS
-        Gets the OpenAIKey module scope variable or environment variable is set.
+        Gets the OpenAIKey module scope variable or environment variable.
 
         .EXAMPLE
         Get-OpenAIKey

--- a/Private/Get-OpenAIKey.ps1
+++ b/Private/Get-OpenAIKey.ps1
@@ -7,11 +7,11 @@ function Get-OpenAIKey {
         Get-OpenAIKey
     #>
     if ($null -ne $Script:OpenAIKey) {
-        if ($PSVersionTable.PSVersion.Major -gt 6) {
-            #On PowerShell 7 and higher use AsPlainText parameter
-            ConvertFrom-SecureString -SecureString $Script:OpenAIKey -AsPlainText
+        if ($PSVersionTable.PSVersion.Major -gt 5) {
+            #On PowerShell 6 and higher return secure string because Invoke-RestMethod supports Bearer authentication with secure Token
+            $Script:OpenAIKey
         } else {
-            #On PowerShell 6 and lower use .NET marshaling
+            #On PowerShell 5 and lower use .NET marshaling to convert the secure string to plain text
             [Runtime.InteropServices.Marshal]::PtrToStringAuto(
                 [Runtime.InteropServices.Marshal]::SecureStringToBSTR($Script:OpenAIKey)
             )

--- a/Private/Get-OpenAIKey.ps1
+++ b/Private/Get-OpenAIKey.ps1
@@ -1,6 +1,21 @@
 function Get-OpenAIKey {
+    <#
+        .SYNOPSIS
+        Gets the OpenAIKey module scope variable or environment variable is set.
+
+        .EXAMPLE
+        Get-OpenAIKey
+    #>
     if ($null -ne $Script:OpenAIKey) {
-        ConvertFrom-SecureString -SecureString $Script:OpenAIKey -AsPlainText
+        if ($PSVersionTable.PSVersion.Major -gt 6) {
+            #On PowerShell 7 and higher use AsPlainText parameter
+            ConvertFrom-SecureString -SecureString $Script:OpenAIKey -AsPlainText
+        } else {
+            #On PowerShell 6 and lower use .NET marshaling
+            [Runtime.InteropServices.Marshal]::PtrToStringAuto(
+                [Runtime.InteropServices.Marshal]::SecureStringToBSTR($Script:OpenAIKey)
+            )
+        }
     } else {
         $env:OpenAIKey
     }

--- a/Public/Invoke-OpenAIAPI.ps1
+++ b/Public/Invoke-OpenAIAPI.ps1
@@ -28,15 +28,23 @@ function Invoke-OpenAIAPI {
     )
 
     if (!(Test-OpenAIKey)) {
-        throw 'Please set your OpenAI API key using Set-OpenAIKey or by configuring the $env:OpenAIKey environment variable. https://beta.openai.com/account/api-keys'
+        throw 'Please set your OpenAI API key using Set-OpenAIKey or by configuring the $env:OpenAIKey environment variable (https://beta.openai.com/account/api-keys)'
     }
 
     $params = @{
         Uri         = $Uri
         Method      = $Method
-        Headers     = @{Authorization = 'Bearer {0}' -f (Get-OpenAIKey)}
         ContentType = 'application/json'
         body        = $Body
+    }
+
+    if (($apiKey = Get-OpenAIKey) -is [SecureString]) {
+        #On PowerShell 6 and higher use Invoke-RestMethod with Authentication parameter and secure Token
+        $params['Authentication'] = 'Bearer'
+        $params['Token'] = $apiKey
+    } else {
+        #On PowerShell 5 and lower, or when using the $env:OpenAIKey environment variable, use Invoke-RestMethod with plain text header
+        $params['Headers'] = @{Authorization = "Bearer $apiKey"}
     }
 
     Invoke-RestMethod @params

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ In the PowerShell console:
 Install-Module -Name PowerShellAI
 ```
 
-Get/Create your OpenAI API key from [https://beta.openai.com/account/api-keys](https://beta.openai.com/account/api-keys) and then set `$env:OpenAIKey`.
+Get/Create your OpenAI API key from [https://beta.openai.com/account/api-keys](https://beta.openai.com/account/api-keys) and then set as *secure string* with `Set-OpenAIKey` or as *plain text* with `$env:OpenAIKey`.
 
 ## Examples
 Check out these PowerShell scripts to see how easy it is to get started with AI in PowerShell:
@@ -135,7 +135,7 @@ ai "list of planets only names as json"
     "Neptune"
 ]
 ```
- 
+
 
 ```powershell
 ai "list of planets only names as json" | ai 'convert to  xml'
@@ -153,7 +153,7 @@ ai "list of planets only names as json" | ai 'convert to  xml'
     <Planet>Uranus</Planet>
     <Planet>Neptune</Planet>
 </Planets>
-```        
+```
 
 ```powershell
 ai "list of planets only names as json" | ai 'convert to  xml' | ai 'convert to  powershell'
@@ -259,7 +259,7 @@ Try it out: `New-Spreadsheet "list of first 5 US presidents name, term"`
 
 ## Check out the Video
 
-<a href="https://youtu.be/Aehsgtll1CA"><img src="https://img.youtube.com/vi/Aehsgtll1CA/0.jpg" width="200"> 
+<a href="https://youtu.be/Aehsgtll1CA"><img src="https://img.youtube.com/vi/Aehsgtll1CA/0.jpg" width="200">
 
 # DALL-E
 
@@ -274,5 +274,5 @@ Set-DalleImageAsBackground "A picture of a cat"
 You can also use the `Get-DalleImage` function to get the image and it saves to a temp file, ready to use.
 
 ```powershell
-Get-DalleImage "A picture of a cat" 
+Get-DalleImage "A picture of a cat"
 ```

--- a/__tests__/Get-OpenAIKey.tests.ps1
+++ b/__tests__/Get-OpenAIKey.tests.ps1
@@ -1,0 +1,60 @@
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', '', Justification='$secureStringKey and $environmentVariableKey variables are used in tests')]
+param()
+
+Describe "Get-OpenAIKey" -Tag 'GetOpenAIKey' {
+    BeforeEach {
+        Remove-Module 'PowerShellAI' -Force
+        Import-Module "$PSScriptRoot\..\PowerShellAI.psd1" -Force
+    }
+
+    AfterEach {
+        $env:OpenAIKey = $null
+    }
+
+    InModuleScope 'PowerShellAI' {
+        BeforeAll {
+            $secureStringKey = 'OpenAIKeySecureString'
+            $environmentVariableKey = 'OpenAIKeyEnvironmentVariable'
+        }
+
+        It 'Should return value of type [String] when $env:OpenAIKey is set' {
+            $env:OpenAIKey = $environmentVariableKey
+            Get-OpenAIKey | Should -BeOfType 'System.String'
+        }
+
+        It 'Should return the same value as set in $env:OpenAIKey' {
+            $env:OpenAIKey = $environmentVariableKey
+            Get-OpenAIKey | Should -BeExactly $env:OpenAIKey
+        }
+
+        It 'Should return value of type [String] on PowerShell 5 and lower' -Skip:($PSVersionTable.PSVersion.Major -gt 5) {
+            Set-OpenAIKey -Key (ConvertTo-SecureString -String $secureStringKey -AsPlainText -Force)
+            Get-OpenAIKey | Should -BeOfType 'System.String'
+        }
+
+        It 'Should return the same value as set with Set-OpenAIKey on PowerShell 5 and lower' -Skip:($PSVersionTable.PSVersion.Major -gt 5) {
+            Set-OpenAIKey -Key (ConvertTo-SecureString -String $secureStringKey -AsPlainText -Force)
+            Get-OpenAIKey | Should -BeExactly $secureStringKey
+        }
+
+        It 'Should return value of type [SecureString] on PowerShell 6 and higher' -Skip:($PSVersionTable.PSVersion.Major -lt 6) {
+            Set-OpenAIKey -Key (ConvertTo-SecureString -String $secureStringKey -AsPlainText -Force)
+            Get-OpenAIKey | Should -BeOfType 'System.Security.SecureString'
+        }
+
+        It 'Should return the same value as set with Set-OpenAIKey on PowerShell 6 and higher' -Skip:($PSVersionTable.PSVersion.Major -lt 6) {
+            Set-OpenAIKey -Key (ConvertTo-SecureString -String $secureStringKey -AsPlainText -Force)
+            Get-OpenAIKey | ConvertFrom-SecureString -AsPlainText | Should -BeExactly $secureStringKey
+        }
+
+        It 'OpenAI key configured with Set-OpenAIKey has priority over $env:OpenAIKey' {
+            $env:OpenAIKey = $environmentVariableKey
+            Set-OpenAIKey -Key (ConvertTo-SecureString -String $secureStringKey -AsPlainText -Force)
+            if ($PSVersionTable.PSVersion.Major -gt 5) {
+                Get-OpenAIKey | ConvertFrom-SecureString -AsPlainText | Should -BeExactly $secureStringKey
+            } else {
+                Get-OpenAIKey | Should -BeExactly $secureStringKey
+            }
+        }
+    }
+}

--- a/__tests__/Set-OpenAIKey.tests.ps1
+++ b/__tests__/Set-OpenAIKey.tests.ps1
@@ -9,7 +9,7 @@ Describe "Set-OpenAIKey" -Tag 'SetOpenAIKey' {
         {Set-OpenAIKey -Key ([System.Security.SecureString]::new())} | Should -Throw
     }
 
-    It "Should throw when Key parameter value is not of [SecureString] type" {
+    It "Should throw when Key parameter value is not of type [SecureString]" {
         {Set-OpenAIKey -Key 'NotSecureStringType'} | Should -Throw
     }
 

--- a/__tests__/Set-OpenAIKey.tests.ps1
+++ b/__tests__/Set-OpenAIKey.tests.ps1
@@ -1,0 +1,19 @@
+Import-Module "$PSScriptRoot\..\PowerShellAI.psd1" -Force
+
+Describe "Set-OpenAIKey" -Tag 'SetOpenAIKey' {
+    It "Should throw when Key is null" {
+		{Set-OpenAIKey -Key $null} | Should -Throw
+    }
+
+	It "Should throw when Key is empty" {
+        {Set-OpenAIKey -Key ([System.Security.SecureString]::new())} | Should -Throw
+    }
+
+	It "Should throw when Key is not SecureString type" {
+        {Set-OpenAIKey -Key 'NotSecureStringType'} | Should -Throw
+    }
+
+	It "Should accept valid secure string as Key" {
+        {Set-OpenAIKey -Key (ConvertTo-SecureString -String 'FakeOpenAIKey' -AsPlainText -Force)} | Should -Not -Throw
+    }
+}

--- a/__tests__/Set-OpenAIKey.tests.ps1
+++ b/__tests__/Set-OpenAIKey.tests.ps1
@@ -1,19 +1,19 @@
 Import-Module "$PSScriptRoot\..\PowerShellAI.psd1" -Force
 
 Describe "Set-OpenAIKey" -Tag 'SetOpenAIKey' {
-    It "Should throw when Key is null" {
+    It "Should throw when Key parameter value is null" {
         {Set-OpenAIKey -Key $null} | Should -Throw
     }
 
-    It "Should throw when Key is empty" {
+    It "Should throw when Key parameter value is empty" {
         {Set-OpenAIKey -Key ([System.Security.SecureString]::new())} | Should -Throw
     }
 
-    It "Should throw when Key is not SecureString type" {
+    It "Should throw when Key parameter value is not of [SecureString] type" {
         {Set-OpenAIKey -Key 'NotSecureStringType'} | Should -Throw
     }
 
-    It "Should accept valid secure string as Key" {
+    It "Should accept valid secure string as Key parameter value" {
         {Set-OpenAIKey -Key (ConvertTo-SecureString -String 'FakeOpenAIKey' -AsPlainText -Force)} | Should -Not -Throw
     }
 }

--- a/__tests__/Set-OpenAIKey.tests.ps1
+++ b/__tests__/Set-OpenAIKey.tests.ps1
@@ -2,18 +2,18 @@ Import-Module "$PSScriptRoot\..\PowerShellAI.psd1" -Force
 
 Describe "Set-OpenAIKey" -Tag 'SetOpenAIKey' {
     It "Should throw when Key is null" {
-		{Set-OpenAIKey -Key $null} | Should -Throw
+        {Set-OpenAIKey -Key $null} | Should -Throw
     }
 
-	It "Should throw when Key is empty" {
+    It "Should throw when Key is empty" {
         {Set-OpenAIKey -Key ([System.Security.SecureString]::new())} | Should -Throw
     }
 
-	It "Should throw when Key is not SecureString type" {
+    It "Should throw when Key is not SecureString type" {
         {Set-OpenAIKey -Key 'NotSecureStringType'} | Should -Throw
     }
 
-	It "Should accept valid secure string as Key" {
+    It "Should accept valid secure string as Key" {
         {Set-OpenAIKey -Key (ConvertTo-SecureString -String 'FakeOpenAIKey' -AsPlainText -Force)} | Should -Not -Throw
     }
 }

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+# v0.4.7
+- Thank you [Kris Borowinski](https://github.com/kborowinski)
+    - On PS 6 and higher use Invoke-RestMethod with secure Token
+
 # v0.4.6
 - Thank you to [Pieter Jan Geutjens](https://github.com/pjgeutjens)
     - `Get-OpenAIEdit` works both with pipeline input as well as `-InputText` param


### PR DESCRIPTION
@dfinke:
This PR brings following changes to `Get-OpenAIKey` function:
1. Returns *secure string* on **PowerShell 6** and higher, when `Set-OpenAIKey` was used to configure the OpenAI key
2. Returns *plain text* on **PowerShell 5** and lower, when `Set-OpenAIKey` was used to configure the OpenAI key *(`Invoke-RestMethod` does not support secure tokens on PS 5)*
3. Returns *plain text* when `$env:OpenAIKey` environment variable was used to store the OpenAI key

This allows to use secure token with OpenAIKey for bearer authentication on PowerShell 6 and higher *(the OpenAIKey stays secure and never gets converted to plain text)*

On PowerShell 5 the OpenAIKey token is passed as *clear text* in the authentication header. Same for `$env:OpenAIKey`.
