### PR TITLE
Update README.md - remove duplicate line + fixed example

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,6 @@ Check out these PowerShell scripts to see how easy it is to get started with AI 
 | Get-DalleImage | Get an image from the OpenAI DALL-E API | [Get-DalleImage.ps1](./Public/Get-DalleImage.ps1)
 | ai | Experimental AI function that you can pipe all sorts of things into and get back a completion | [ai.ps1](./Public/ai.ps1)
 | copilot | Makes the request to GPT, parses the response and displays it in a box and then prompts the user to run the code or not. | [copilot.ps1](./Public/copilot.ps1)
-| Get-DalleImage | Get an image from the OpenAI DALL-E API | [Get-DalleImage.ps1](./Public/Get-DalleImage.ps1)
 | Set-DalleImageAsWallpaper | Set the image from the OpenAI DALL-E API as the wallpaper | [Set-DalleImageAsWallpaper.ps1](./Public/Set-DalleImageAsWallpaper.ps1)
 | Invoke-AIErrorHelper | Helper function let ChatGPT add more info about errors | [Invoke-AIErrorHelper.ps1](./Public/Invoke-AIErrorHelper.ps1)
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Check out these PowerShell scripts to see how easy it is to get started with AI 
 
 ## Demos of the PowerShellAI
 
-Here are some vidoes of `PowerShellAI` in action:
+Here are some videos of `PowerShellAI` in action:
 
 | Description | YouTube Video |
 |--|--|

--- a/README.md
+++ b/README.md
@@ -230,11 +230,11 @@ You can also use the alias `ieh`.
 
 Unlike completions, edits takes two inputs: the `text` to edit and an `instruction`. Here the `model` is set to `code-davinci-edit-001` because we're working with PowerShell code.
 
-- Here you're passing in the string that is a PowerShell function.
+- Here you're passing in the string (`InputText`) that is a PowerShell function.
 - The `instruction` is to `add a comment-based help detailed description`
 
 ```powershell
-Get-OpenAIEdit @'
+Get-OpenAIEdit -InputText @'
 function greet {
     param($n)
 


### PR DESCRIPTION
1. Ln 50 and Ln 53 are the same
2. The example required the parameter name `InputText` otherwise it would error out.