### PR TITLE
Import module only once and restore existing $env:OpenAIKey after tests

### DIFF
--- a/__tests__/Get-LocalOpenAIKey.tests.ps1
+++ b/__tests__/Get-LocalOpenAIKey.tests.ps1
@@ -1,20 +1,20 @@
-[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', '', Justification='$secureStringKey and $environmentVariableKey variables are used in tests')]
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', '', Justification='BeforeAll block variables are used in tests')]
 param()
 
+Import-Module "$PSScriptRoot\..\PowerShellAI.psd1" -Force
+
 Describe "Get-LocalOpenAIKey" -Tag 'GetLocalOpenAIKey' {
-    BeforeEach {
-        Remove-Module 'PowerShellAI' -Force
-        Import-Module "$PSScriptRoot\..\PowerShellAI.psd1" -Force
-    }
-
-    AfterEach {
-        $env:OpenAIKey = $null
-    }
-
     InModuleScope 'PowerShellAI' {
         BeforeAll {
+            #Backup existing OpenAIKey
+            $backupOpenAIKey = $env:OpenAIKey
+
             $secureStringKey = 'OpenAIKeySecureString'
             $environmentVariableKey = 'OpenAIKeyEnvironmentVariable'
+        }
+
+        BeforeEach {
+            $Script:OpenAIKey, $env:OpenAIKey = $null
         }
 
         It 'Should return value of type [String] when $env:OpenAIKey is set' {
@@ -57,6 +57,11 @@ Describe "Get-LocalOpenAIKey" -Tag 'GetLocalOpenAIKey' {
             } else {
                 Get-LocalOpenAIKey | Should -BeExactly $secureStringKey
             }
+        }
+
+        AfterAll {
+            #Restore OpenAIKey
+            $env:OpenAIKey = $backupOpenAIKey
         }
     }
 }


### PR DESCRIPTION
@dfinke I had couple of minutes this morning so I fixed the issue #84. Have look at it.