### PR TITLE
Copilot prompt change, adding clipboard

### DIFF
--- a/Private/CustomReadHost.ps1
+++ b/Private/CustomReadHost.ps1
@@ -7,10 +7,10 @@ function CustomReadHost {
         CustomReadHost 
     #>
 
-    $Yes = New-Object System.Management.Automation.Host.ChoiceDescription '&Yes', 'Yes, run the code'    
+    $Run = New-Object System.Management.Automation.Host.ChoiceDescription '&Yes', 'Yes, run the code'    
     $Explain = New-Object System.Management.Automation.Host.ChoiceDescription '&Explain', 'Explain the code'
     $Copy = New-Object System.Management.Automation.Host.ChoiceDescription '&Copy', 'Copy to clipboard'    
-    $No = New-Object System.Management.Automation.Host.ChoiceDescription '&No', 'No, do not run the code'
+    $Nothing = New-Object System.Management.Automation.Host.ChoiceDescription '&No', 'No, do not run the code'
 
     $options = [System.Management.Automation.Host.ChoiceDescription[]]($Run, $Explain, $Copy, $Nothing)
 

--- a/Private/CustomReadHost.ps1
+++ b/Private/CustomReadHost.ps1
@@ -7,13 +7,13 @@ function CustomReadHost {
         CustomReadHost 
     #>
 
-    $Run = New-Object System.Management.Automation.Host.ChoiceDescription '&Run', 'Run the code'    
+    $Yes = New-Object System.Management.Automation.Host.ChoiceDescription '&Yes', 'Yes, run the code'    
     $Explain = New-Object System.Management.Automation.Host.ChoiceDescription '&Explain', 'Explain the code'
     $Copy = New-Object System.Management.Automation.Host.ChoiceDescription '&Copy', 'Copy to clipboard'    
-    $Nothing = New-Object System.Management.Automation.Host.ChoiceDescription '&Nothing', 'Do not run the code'
+    $No = New-Object System.Management.Automation.Host.ChoiceDescription '&No', 'No, do not run the code'
 
     $options = [System.Management.Automation.Host.ChoiceDescription[]]($Run, $Explain, $Copy, $Nothing)
 
-    $message = 'What would you like to do?'
+    $message = 'Run the code? You can also choose additional actions'
     $host.ui.PromptForChoice($null, $message, $options, 3)
 }

--- a/Private/CustomReadHost.ps1
+++ b/Private/CustomReadHost.ps1
@@ -7,12 +7,13 @@ function CustomReadHost {
         CustomReadHost 
     #>
 
-    $Yes = New-Object System.Management.Automation.Host.ChoiceDescription '&Yes', 'Yes, run the code'    
-    $Explain = New-Object System.Management.Automation.Host.ChoiceDescription '&Explain', 'Yes, explain the code'    
-    $No = New-Object System.Management.Automation.Host.ChoiceDescription '&No', 'No, do not run the code'
+    $Run = New-Object System.Management.Automation.Host.ChoiceDescription '&Run', 'Run the code'    
+    $Explain = New-Object System.Management.Automation.Host.ChoiceDescription '&Explain', 'Explain the code'
+    $Copy = New-Object System.Management.Automation.Host.ChoiceDescription '&Copy', 'Copy to clipboard'    
+    $Nothing = New-Object System.Management.Automation.Host.ChoiceDescription '&Nothing', 'Do not run the code'
 
-    $options = [System.Management.Automation.Host.ChoiceDescription[]]($Yes, $Explain, $No)
+    $options = [System.Management.Automation.Host.ChoiceDescription[]]($Run, $Explain, $Copy, $Nothing)
 
     $message = 'What would you like to do?'
-    $host.ui.PromptForChoice($null, $message, $options, 2)
+    $host.ui.PromptForChoice($null, $message, $options, 3)
 }

--- a/Public/copilot.ps1
+++ b/Public/copilot.ps1
@@ -108,6 +108,9 @@ function copilot {
             1 {
                 explain -Value (Get-Runnable -result $result)
             }
+            2 {
+                Get-Runnable -result $result | Set-Clipboard
+            }
             default { "Not running" }
         }
     }


### PR DESCRIPTION
Proposing change of the `copilot` prompt to make `Yes` and `No` grammatically proper choices.
Adding clipboard functionality to `copilot`

Resolves #104