### PR TITLE
Wrap the whole thing and use Stop-Chat in a finally block to guarante…

### DIFF
--- a/__tests__/Invoke-AIFunctionBuilder.tests.ps1
+++ b/__tests__/Invoke-AIFunctionBuilder.tests.ps1
@@ -17,6 +17,11 @@ Describe "Invoke-AIFunctionBuilder" -Tag 'Invoke-AIFunctionBuilder' {
                 Function = "Get-GPT3Completion"
                 Parameters = @("prompt", "max_tokens")
                 Description = "This function is used for quick completions that don't require chat context"
+            },
+            @{
+                Function = "Stop-Chat"
+                Parameters = @()
+                Description = "This function is used at the end to clear the current chat history"
             }
         )
 


### PR DESCRIPTION
Fixes #111 

Wrapped the whole main function and used Stop-Chat in a finally block to guarantee it gets called if the script is stopped with ctrl-c, a terminating error or if it finished successfully.

It's easier this way than using a trap for terminating errors and trying to find all the places that chats are used and using stop-chat for each one.

```pwsh
try {
    # do stuff
} finally {
    Stop-Chat
}
```