### PR TITLE
wip - investigate using Write-Codeblock

### DIFF
--- a/PowerShellAI.psd1
+++ b/PowerShellAI.psd1
@@ -1,6 +1,6 @@
 @{
     RootModule        = 'PowerShellAI.psm1'
-    ModuleVersion     = '0.5.8'
+    ModuleVersion     = '0.6.1'
     GUID              = '081ce7b4-6e63-41ca-92a7-2bf72dbad018'
     Author            = 'Douglas Finke'
     CompanyName       = 'Doug Finke'

--- a/Private/CustomReadHost.ps1
+++ b/Private/CustomReadHost.ps1
@@ -10,9 +10,9 @@ function CustomReadHost {
     $Run = New-Object System.Management.Automation.Host.ChoiceDescription '&Yes', 'Yes, run the code'    
     $Explain = New-Object System.Management.Automation.Host.ChoiceDescription '&Explain', 'Explain the code'
     $Copy = New-Object System.Management.Automation.Host.ChoiceDescription '&Copy', 'Copy to clipboard'    
-    $Nothing = New-Object System.Management.Automation.Host.ChoiceDescription '&No', 'No, do not run the code'
+    $Quit = New-Object System.Management.Automation.Host.ChoiceDescription '&Quit', 'Do not run the code'
 
-    $options = [System.Management.Automation.Host.ChoiceDescription[]]($Run, $Explain, $Copy, $Nothing)
+    $options = [System.Management.Automation.Host.ChoiceDescription[]]($Run, $Explain, $Copy, $Quit)
 
     $message = 'Run the code? You can also choose additional actions'
     $host.ui.PromptForChoice($null, $message, $options, 3)

--- a/Public/Invoke-AIExplain.ps1
+++ b/Public/Invoke-AIExplain.ps1
@@ -42,6 +42,7 @@ function Invoke-AIExplain {
     
     $result = $cli | ai $prompt -max_tokens $max_tokens
 
-    Write-Host $cli -ForegroundColor Green
+    #Write-Host $cli -ForegroundColor Green
+    Write-Codeblock -Text $cli -SyntaxHighlight
     $result
 }

--- a/Public/copilot.ps1
+++ b/Public/copilot.ps1
@@ -99,6 +99,11 @@ function copilot {
         $result += $completion
 
         $runnable = Get-Runnable -result $result
+        
+        if (Test-AifbScriptAnalyzerAvailable) {
+            $runnable = Invoke-Formatter -ScriptDefinition $runnable -Verbose:$false
+        }
+
         Write-Codeblock -Text $runnable -ShowLineNumbers -SyntaxHighlight
 
         # $result | CreateBoxText

--- a/Public/copilot.ps1
+++ b/Public/copilot.ps1
@@ -106,21 +106,19 @@ function copilot {
 
         Write-Codeblock -Text $runnable -ShowLineNumbers -SyntaxHighlight
 
-        # $result | CreateBoxText
-
-        # $userInput = CustomReadHost
+        $userInput = CustomReadHost
         
-        # switch ($userInput) {
-        #     0 {
-        #         (Get-Runnable -result $result) | Invoke-Expression
-        #     }
-        #     1 {
-        #         explain -Value (Get-Runnable -result $result)
-        #     }
-        #     2 {
-        #         Get-Runnable -result $result | Set-Clipboard
-        #     }
-        #     default { "Not running" }
-        # }
+        switch ($userInput) {
+            0 {
+                (Get-Runnable -result $result) | Invoke-Expression
+            }
+            1 {
+                explain -Value (Get-Runnable -result $result)
+            }
+            2 {
+                Get-Runnable -result $result | Set-Clipboard
+            }
+            default { "Not running" }
+        }
     }
 }

--- a/Public/copilot.ps1
+++ b/Public/copilot.ps1
@@ -93,25 +93,29 @@ function copilot {
         return $completion
     }
     else {
+
         $result = @($inputPrompt)
         $result += ''
         $result += $completion
 
-        $result | CreateBoxText
+        $runnable = Get-Runnable -result $result
+        Write-Codeblock -Text $runnable -ShowLineNumbers -SyntaxHighlight
 
-        $userInput = CustomReadHost
+        # $result | CreateBoxText
+
+        # $userInput = CustomReadHost
         
-        switch ($userInput) {
-            0 {
-                (Get-Runnable -result $result) | Invoke-Expression
-            }
-            1 {
-                explain -Value (Get-Runnable -result $result)
-            }
-            2 {
-                Get-Runnable -result $result | Set-Clipboard
-            }
-            default { "Not running" }
-        }
+        # switch ($userInput) {
+        #     0 {
+        #         (Get-Runnable -result $result) | Invoke-Expression
+        #     }
+        #     1 {
+        #         explain -Value (Get-Runnable -result $result)
+        #     }
+        #     2 {
+        #         Get-Runnable -result $result | Set-Clipboard
+        #     }
+        #     default { "Not running" }
+        # }
     }
 }


### PR DESCRIPTION
@ShaunLawrie 
- Do I need to pass the code to ScriptAnalyzer to "autoformat"?
- Does `Write-Codeblock` handle that?
- For the "menu" is that reusable? Can I pipe Write-Codeblock to it and it appends the choices?

```powershell
copilot 'write a function to greet'
```

![image](https://user-images.githubusercontent.com/67258/233749121-303752cb-ae25-42d8-853c-2166e462ba77.png)
