### PR TITLE
Fixing temp file path by escaping string.

### DIFF
--- a/Public/Get-DalleImage.ps1
+++ b/Public/Get-DalleImage.ps1
@@ -44,7 +44,7 @@ function Get-DalleImage {
         return $result
     }
     else {
-        $DestinationPath = [IO.Path]::GetTempFileName() -replace ".tmp", ".png"
+        $DestinationPath = [IO.Path]::GetTempFileName() -replace ([regex]::Escape(".tmp")), ".png"
         Invoke-RestMethod $result.data.url -OutFile $DestinationPath
         $DestinationPath
     }


### PR DESCRIPTION
Before: `\Local\Temp.png8039.png`
After: `\Local\Temp\tmp803A.png`