### PR TITLE
Add PSDrive support for Invoke-RestMethodWithProgress

### DIFF
--- a/Private/Invoke-RestMethodWithProgress.ps1
+++ b/Private/Invoke-RestMethodWithProgress.ps1
@@ -41,8 +41,10 @@ function Invoke-RestMethodWithProgress {
         $ProgressActivity = "Thinking..."
     )
 
+    $currentLocation = Get-Location
+
     # Some hosts can't support background jobs. It's best to opt-in to this feature by using a list of supported hosts
-    if($script:SupportedHosts -notcontains (Get-Host).Name) {
+    if($script:SupportedHosts -notcontains (Get-Host).Name -or $currentLocation.Provider.Name -ne "FileSystem") {
         return Invoke-RestMethod @Params
     }
 
@@ -51,6 +53,11 @@ function Invoke-RestMethodWithProgress {
     try {
         try { [Console]::CursorVisible = $false }
         catch [System.IO.IOException] { <# unit tests don't have a console #> }
+
+        Push-Location -StackName "RestMethodWithProgress"
+        if($currentLocation.Path -ne $currentLocation.ProviderPath) {
+            Set-Location $here.ProviderPath
+        }
         
         $job = Start-Job {
             $restParameters = $using:Params
@@ -87,6 +94,7 @@ function Invoke-RestMethodWithProgress {
     } catch {
         throw $_
     } finally {
+        Pop-Location -StackName "RestMethodWithProgress" -ErrorAction "SilentlyContinue"
         Stop-Job $job -ErrorAction "SilentlyContinue"
         Remove-Job $job -Force -ErrorAction "SilentlyContinue"
         try { [Console]::CursorVisible = $true }

--- a/Private/Invoke-RestMethodWithProgress.ps1
+++ b/Private/Invoke-RestMethodWithProgress.ps1
@@ -56,7 +56,7 @@ function Invoke-RestMethodWithProgress {
 
         Push-Location -StackName "RestMethodWithProgress"
         if($currentLocation.Path -ne $currentLocation.ProviderPath) {
-            Set-Location $here.ProviderPath
+            Set-Location $currentLocation.ProviderPath
         }
         
         $job = Start-Job {
@@ -95,8 +95,10 @@ function Invoke-RestMethodWithProgress {
         throw $_
     } finally {
         Pop-Location -StackName "RestMethodWithProgress" -ErrorAction "SilentlyContinue"
-        Stop-Job $job -ErrorAction "SilentlyContinue"
-        Remove-Job $job -Force -ErrorAction "SilentlyContinue"
+        if($null -ne $job) {
+            Stop-Job $job -ErrorAction "SilentlyContinue"
+            Remove-Job $job -Force -ErrorAction "SilentlyContinue"
+        }
         try { [Console]::CursorVisible = $true }
         catch [System.IO.IOException] { <# unit tests don't have a console #> }
     }

--- a/__tests__/Invoke-RestMethodWithProgress.tests.ps1
+++ b/__tests__/Invoke-RestMethodWithProgress.tests.ps1
@@ -8,11 +8,11 @@ Describe "Invoke-RestMethodWithProgress" -Tag InvokeRestMethodWithProgress {
 
         BeforeEach {
             Reset-APIEstimatedResponseTimes
-            New-PSDrive -Name "MOCK-IRMWP" -PSProvider "FileSystem" -Root $PSScriptRoot
+            Push-Location -StackName "MOCK-IRMWP" -Path $PSScriptRoot
         }
 
         AfterEach {
-            Remove-PSDrive -Name "MOCK-IRMWP" -ErrorAction "SilentlyContinue"
+            Pop-Location -StackName "MOCK-IRMWP" -ErrorAction "SilentlyContinue"
         }
 
         It "should return the known response if the API call is successful" {
@@ -53,13 +53,10 @@ Describe "Invoke-RestMethodWithProgress" -Tag InvokeRestMethodWithProgress {
                 "Uri" = "http://localhost";
             }
 
-            Push-Location -StackName "MOCK-IRMWP"
-            Set-Location "MOCK-IRMWP:\"
+            Set-Location "Temp:\"
             
             $response = Invoke-RestMethodWithProgress -Params $params
             $response | Should -BeExactly "a happy web response from a web server"
-            
-            Pop-Location -StackName "MOCK-IRMWP"
         }
 
         It "should work when run from a non-filesystem provider" {
@@ -76,14 +73,12 @@ Describe "Invoke-RestMethodWithProgress" -Tag InvokeRestMethodWithProgress {
             }
 
             Push-Location -StackName "MOCK-IRMWP"
-            Set-Location "HKCU:\"
+            Set-Location "Env:\"
             
             $response = Invoke-RestMethodWithProgress -Params $params
             $response | Should -BeExactly "a happy web response from a web server"
             Should -Invoke -CommandName Invoke-RestMethod -Times 1
             Should -Invoke -CommandName Start-Job -Times 0
-            
-            Pop-Location -StackName "MOCK-IRMWP"
         }
 
         It "should throw if the API call fails" {

--- a/__tests__/Invoke-RestMethodWithProgress.tests.ps1
+++ b/__tests__/Invoke-RestMethodWithProgress.tests.ps1
@@ -9,7 +9,7 @@ Describe "Invoke-RestMethodWithProgress" -Tag InvokeRestMethodWithProgress {
         BeforeEach {
             Reset-APIEstimatedResponseTimes
             Push-Location -StackName "MOCK-IRMWP" -Path $PSScriptRoot
-            New-PSDrive -Name "MOCK-IRMWP" -PSProvider "FileSystem" -Root $env:TEMP
+            New-PSDrive -Name "MOCK-IRMWP" -PSProvider "FileSystem" -Root $PSScriptRoot
         }
 
         AfterEach {

--- a/__tests__/Invoke-RestMethodWithProgress.tests.ps1
+++ b/__tests__/Invoke-RestMethodWithProgress.tests.ps1
@@ -9,10 +9,12 @@ Describe "Invoke-RestMethodWithProgress" -Tag InvokeRestMethodWithProgress {
         BeforeEach {
             Reset-APIEstimatedResponseTimes
             Push-Location -StackName "MOCK-IRMWP" -Path $PSScriptRoot
+            New-PSDrive -Name "MOCK-IRMWP" -PSProvider "FileSystem" -Root $env:TEMP
         }
 
         AfterEach {
             Pop-Location -StackName "MOCK-IRMWP" -ErrorAction "SilentlyContinue"
+            Remove-PSDrive -Name "MOCK-IRMWP" -ErrorAction "SilentlyContinue"
         }
 
         It "should return the known response if the API call is successful" {
@@ -53,7 +55,7 @@ Describe "Invoke-RestMethodWithProgress" -Tag InvokeRestMethodWithProgress {
                 "Uri" = "http://localhost";
             }
 
-            Set-Location "Temp:\"
+            Set-Location "MOCK-IRMWP:\"
             
             $response = Invoke-RestMethodWithProgress -Params $params
             $response | Should -BeExactly "a happy web response from a web server"

--- a/__tests__/Invoke-RestMethodWithProgress.tests.ps1
+++ b/__tests__/Invoke-RestMethodWithProgress.tests.ps1
@@ -8,6 +8,11 @@ Describe "Invoke-RestMethodWithProgress" -Tag InvokeRestMethodWithProgress {
 
         BeforeEach {
             Reset-APIEstimatedResponseTimes
+            New-PSDrive -Name "MOCK-IRMWP" -PSProvider "FileSystem" -Root $PSScriptRoot
+        }
+
+        AfterEach {
+            Remove-PSDrive -Name "MOCK-IRMWP" -ErrorAction "SilentlyContinue"
         }
 
         It "should return the known response if the API call is successful" {
@@ -29,6 +34,56 @@ Describe "Invoke-RestMethodWithProgress" -Tag InvokeRestMethodWithProgress {
             
             $response = Invoke-RestMethodWithProgress -Params $params
             $response | Should -BeExactly "a happy web response from a web server"
+        }
+
+        It "should work when run from a psdrive" {
+
+            Mock Start-Job {
+                return & $script:StartJobCommand { }
+            }
+            
+            Mock Receive-Job {
+                return @{
+                    Response = "a happy web response from a web server"
+                }
+            }
+
+            $params = @{
+                "Method" = "GET";
+                "Uri" = "http://localhost";
+            }
+
+            Push-Location -StackName "MOCK-IRMWP"
+            Set-Location "MOCK-IRMWP:\"
+            
+            $response = Invoke-RestMethodWithProgress -Params $params
+            $response | Should -BeExactly "a happy web response from a web server"
+            
+            Pop-Location -StackName "MOCK-IRMWP"
+        }
+
+        It "should work when run from a non-filesystem provider" {
+            
+            Mock Invoke-RestMethod {
+                return "a happy web response from a web server"
+            }
+
+            Mock Start-Job { }
+
+            $params = @{
+                "Method" = "GET";
+                "Uri" = "http://localhost";
+            }
+
+            Push-Location -StackName "MOCK-IRMWP"
+            Set-Location "HKCU:\"
+            
+            $response = Invoke-RestMethodWithProgress -Params $params
+            $response | Should -BeExactly "a happy web response from a web server"
+            Should -Invoke -CommandName Invoke-RestMethod -Times 1
+            Should -Invoke -CommandName Start-Job -Times 0
+            
+            Pop-Location -StackName "MOCK-IRMWP"
         }
 
         It "should throw if the API call fails" {


### PR DESCRIPTION
The root of the issue is that `Start-Job` doesn't share a runspace.
Start-Job tries to run in the same directory as the parent session and it fails to Set-Location to custom named PSDrive's.  

This solution:
 - Uses @jdhitsolutions's workaround that sets the location to the provider path before calling `Start-Job`
 - Falls back to using no progress bar if the current directory is not a FileSystem provider because I don't know what size the can of worms could be if I tried to support custom provider paths.

Fixes #148 