### PR TITLE
Add PSScriptAnalyzer settings file.

### DIFF
--- a/PSScriptAnalyzerSettings.psd1
+++ b/PSScriptAnalyzerSettings.psd1
@@ -1,0 +1,46 @@
+# https://learn.microsoft.com/en-us/powershell/utility-modules/psscriptanalyzer/rules/readme?view=ps-modules
+@{
+    IncludeDefaultRules = $true
+    IncludeRules        = @(
+        'PSAlignAssignmentStatement',
+        'PSAvoidLongLines',
+        'PSAvoidUsingDoubleQuotesForConstantString',
+        'PSPlaceOpenBrace',
+        'PSPlaceCloseBrace',
+        'PSUseConsistentIndentation',
+        'PSUseCorrectCasing'
+    )
+
+    Rules               = @{
+        PSAlignAssignmentStatement = @{
+            Enable         = $true
+            CheckHashtable = $true
+        }
+
+        PSAvoidLongLines           = @{
+            Enable            = $true
+            MaximumLineLength = 120
+        }
+
+        PSPlaceOpenBrace           = @{
+            Enable             = $true
+            OnSameLine         = $true
+            NewLineAfter       = $true
+            IgnoreOneLineBlock = $true
+        }
+
+        PSPlaceCloseBrace          = @{
+            Enable             = $true
+            NewLineAfter       = $false
+            IgnoreOneLineBlock = $true
+            NoEmptyLineBefore  = $false
+        }
+
+        PSUseConsistentIndentation = @{
+            Enable              = $true
+            IndentationSize     = 4
+            PipelineIndentation = 'IncreaseIndentationForFirstPipeline'
+            Kind                = 'space'
+        }
+    }
+}


### PR DESCRIPTION
Add [PSScriptAnalyzer settings file](https://learn.microsoft.com/en-us/powershell/utility-modules/psscriptanalyzer/overview?view=ps-modules) that includes the default rules + a few additional rules that I personally use.

These rules can be adjusted as desired.

Running PSScriptAnalyzer on this repo with this settings file:

![Screenshot 2023-07-02 211830](https://github.com/dfinke/PowerShellAI/assets/11180071/75c23bdf-e3fa-4d37-9428-a2c90362239e)

Results file: 
[scriptAnalyzer.txt](https://github.com/dfinke/PowerShellAI/files/11932883/scriptAnalyzer.txt)
