### PR TITLE
Don't use progress bars for users with proxies configured

### DIFF
--- a/Private/Invoke-RestMethodWithProgress.ps1
+++ b/Private/Invoke-RestMethodWithProgress.ps1
@@ -35,16 +35,33 @@ function Set-APIResponseTime {
     $script:EndpointResponseTimeSeconds[$endpointResponseTimeKey] = $ResponseTimeSeconds
 }
 
+function Test-HostSupportsRestMethodWithProgress {
+    # Check if the current host meets all the requirements to be able to send the restmethod to the background
+    
+    if($script:SupportedHosts -notcontains (Get-Host).Name) {
+        return $false
+    }
+
+    $currentLocation = Get-Location
+    if($currentLocation.Provider.Name -ne "FileSystem") {
+        return $false
+    }
+
+    if($null -ne [System.Net.WebRequest]::DefaultWebProxy.Address -or $null -ne $env:HTTP_PROXY) {
+        return $false
+    }
+
+    return $true
+}
+
 function Invoke-RestMethodWithProgress {
     param (
         [hashtable] $Params,
         $ProgressActivity = "Thinking..."
     )
 
-    $currentLocation = Get-Location
-
     # Some hosts can't support background jobs. It's best to opt-in to this feature by using a list of supported hosts
-    if($script:SupportedHosts -notcontains (Get-Host).Name -or $currentLocation.Provider.Name -ne "FileSystem") {
+    if(-not (Test-HostSupportsRestMethodWithProgress)) {
         return Invoke-RestMethod @Params
     }
 

--- a/Private/Invoke-RestMethodWithProgress.ps1
+++ b/Private/Invoke-RestMethodWithProgress.ps1
@@ -72,6 +72,7 @@ function Invoke-RestMethodWithProgress {
         catch [System.IO.IOException] { <# unit tests don't have a console #> }
 
         Push-Location -StackName "RestMethodWithProgress"
+        $currentLocation = Get-Location
         if($currentLocation.Path -ne $currentLocation.ProviderPath) {
             Set-Location $currentLocation.ProviderPath
         }

--- a/__tests__/Invoke-RestMethodWithProgress.tests.ps1
+++ b/__tests__/Invoke-RestMethodWithProgress.tests.ps1
@@ -154,7 +154,7 @@ Describe "Invoke-RestMethodWithProgress" -Tag InvokeRestMethodWithProgress {
             Should -Invoke -CommandName Start-Job -Times 0
         }
 
-        It "should not use a background job if a defaultproxy is configured for the current sessions " {
+        It "should not use a background job if a defaultproxy is configured for the current session" {
             Mock Get-Host {
                 return @{
                     Name = "ConsoleHost"

--- a/__tests__/Invoke-RestMethodWithProgress.tests.ps1
+++ b/__tests__/Invoke-RestMethodWithProgress.tests.ps1
@@ -124,6 +124,66 @@ Describe "Invoke-RestMethodWithProgress" -Tag InvokeRestMethodWithProgress {
             Should -Invoke -CommandName Invoke-RestMethod -Times 1
             Should -Invoke -CommandName Start-Job -Times 0
         }
+        
+        It "should not use a background job if a proxy is configured by env var" {
+            Mock Get-Host {
+                return @{
+                    Name = "ConsoleHost"
+                }
+            }
+
+            Mock Invoke-RestMethod {
+                return "a happy web response from a web server"
+            }
+
+            Mock Start-Job { }
+
+            $params = @{
+                "Method" = "GET";
+                "Uri" = "http://localhost";
+            }
+            
+            $previousProxySettings = $env:HTTP_PROXY
+            $env:HTTP_PROXY = "http://example.com:3128"
+            $response = Invoke-RestMethodWithProgress -Params $params
+            $env:HTTP_PROXY = $previousProxySettings
+            
+            $response | Should -BeExactly "a happy web response from a web server"
+
+            Should -Invoke -CommandName Invoke-RestMethod -Times 1
+            Should -Invoke -CommandName Start-Job -Times 0
+        }
+
+        It "should not use a background job if a defaultproxy is configured for the current sessions " {
+            Mock Get-Host {
+                return @{
+                    Name = "ConsoleHost"
+                }
+            }
+
+            Mock Invoke-RestMethod {
+                return "a happy web response from a web server"
+            }
+
+            Mock Start-Job { }
+
+            $params = @{
+                "Method" = "GET";
+                "Uri" = "http://localhost";
+            }
+            
+            $previousProxySettings = [System.Net.WebRequest]::DefaultWebProxy
+            $proxyUri = New-Object System.Uri("http://example.com:3128")
+            $proxy = New-Object System.Net.WebProxy($proxyUri)
+            [System.Net.WebRequest]::DefaultWebProxy = $proxy
+            $response = Invoke-RestMethodWithProgress -Params $params
+            [System.Net.WebRequest]::DefaultWebProxy = $previousProxySettings
+            
+            $response | Should -BeExactly "a happy web response from a web server"
+
+            Should -Invoke -CommandName Invoke-RestMethod -Times 1
+            Should -Invoke -CommandName Start-Job -Times 0
+        }
 
         Describe "Get-APIEstimatedResponseTime Tests" {
             It "should return default response time when there's no record for a specific endpoint" {


### PR DESCRIPTION
The background job doesn't inherit the proxy settings from the current session so it's easier to just not use one. If you have a proxy you don't get the progress bar.

Fixes #170 