### PR TITLE
Increase Max_Tokens to 4000 for Azure OpenAI

### DIFF
--- a/Public/copilot.ps1
+++ b/Public/copilot.ps1
@@ -68,6 +68,7 @@ function copilot {
         [ValidateRange(0, 2)]
         [decimal]$temperature = 0.0,
         # The maximum number of tokens to generate. default 256
+        [ValidateRange(1, 4000)]
         $max_tokens = 256,
         # Don't show prompt for choice
         [Switch]$Raw


### PR DESCRIPTION
Azure OpenAI supports 4000 for max_tokens. Increase to support default of 256 but option to increase above it.

https://github.com/dfinke/PowerShellAI/issues/173