### PR TITLE
Fix URI for Azure OpenAI

### DIFF
--- a/Public/Get-GPT4Completion.ps1
+++ b/Public/Get-GPT4Completion.ps1
@@ -54,7 +54,7 @@ function Get-ChatAzureOpenAIURI {
         throw 'Azure Open AI ApiVersion not set'
     }
 
-    $uri = "$($options.Endpoint)/openai/deployments/$($options.DeploymentName)/chat/completions?api-version=$($options.ApiVersion)"
+    $uri = "{0}openai/deployments/{1}/chat/completions?api-version={2}" -f $options.Endpoint, $options.DeploymentName, $options.ApiVersion
 
     $uri
 }


### PR DESCRIPTION
Remove the first `/` in the URI because $options.Endpoint contains a trailing forward slash. Previous code would produce `//`.
Also, use the format operator for a cleaner code.