### PR TITLE
Write-Codeblock console host compatibility workaround

### DIFF
--- a/PowerShellAI.psd1
+++ b/PowerShellAI.psd1
@@ -1,6 +1,6 @@
 @{
     RootModule        = 'PowerShellAI.psm1'
-    ModuleVersion     = '0.9.1'
+    ModuleVersion     = '0.9.4'
     GUID              = '081ce7b4-6e63-41ca-92a7-2bf72dbad018'
     Author            = 'Douglas Finke'
     CompanyName       = 'Doug Finke'

--- a/Private/Write-Codeblock.ps1
+++ b/Private/Write-Codeblock.ps1
@@ -61,6 +61,13 @@ function Write-Codeblock {
         [string] $Theme = "Github"
     )
 
+    # Fallback if the console host doesn't expose window dimensions, these are required for token highlighting
+    if(!$Host.UI.RawUI.WindowSize.Width) {
+        Write-Verbose "Could not write codeblock with syntax highlighting because this console host is not exposing window dimentsions."
+        Write-Host -ForegroundColor Gray $Text
+        return
+    }
+
     $ForegroundRgb = $script:Themes[$Theme].ForegroundRgb
     $BackgroundRgb = $script:Themes[$Theme].BackgroundRgb
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+# v0.9.4
+
+- [Shaun Lawrie](https://twitter.com/shaun_lawrie) - Fallback to gray text for the codeblock if the console host doesn't expose window dimensions. This fixes [#200](https://github.com/dfinke/PowerShellAI/issues/200) and potentially [#199](https://github.com/dfinke/PowerShellAI/issues/199) as well.
+
 # v0.9.1
 
 - Remove `Get-ChatCompletion` from `psd1`. It lives in `PowerShellAI.Functions`


### PR DESCRIPTION
Fallback to gray text for the codeblock if the console host doesn't expose window dimensions.

This fixes https://github.com/dfinke/PowerShellAI/issues/200 and potentially https://github.com/dfinke/PowerShellAI/issues/199 as well.