### PR TITLE
text-davinci-003 is deprecated

### DIFF
--- a/Public/Get-OpenAIEdit.ps1
+++ b/Public/Get-OpenAIEdit.ps1
@@ -32,8 +32,8 @@ function Get-OpenAIEdit {
 		[Parameter(Mandatory = $true, Position = 1)]
 		$Instruction,
 		[Parameter()]
-		[ValidateSet('text-davinci-edit-001', 'code-davinci-edit-001')]
-		$model = 'code-davinci-edit-001',
+		[ValidateSet('text-davinci-edit-001', 'code-davinci-edit-001', 'gpt-3.5-turbo-instruct')]
+		$model = 'gpt-3.5-turbo-instruct',
 		[Parameter()]
 		$numberOfEdits = 1,
 		[ValidateRange(0, 2)]


### PR DESCRIPTION
[text-davinci-003 is deprecated](https://platform.openai.com/docs/deprecations/2023-07-06-gpt-and-embeddings)

I circumvented this by doing the following:

`Public\Get-OpenAIEdit.ps1`

Replace Lines 35-36
`[ValidateSet('text-davinci-edit-001', 'code-davinci-edit-001', 'gpt-3.5-turbo-instruct')]
		$model = 'gpt-3.5-turbo-instruct',`

Import-Module -Name "./PowerShellAI.psm1"