### PR TITLE
ai - do not require quotes

### DIFF
--- a/Public/ai.ps1
+++ b/Public/ai.ps1
@@ -16,12 +16,13 @@ function ai {
     #>
     [CmdletBinding()]
     param(
-        $inputPrompt,
-        [Parameter(ValueFromPipeline = $true)]
-        $pipelineInput,
+        [Parameter(Position = 0, ValueFromRemainingArguments)]
+        [string[]]$inputPrompt,
+        [Parameter(ValueFromPipeline)]
+        [psobject[]]$pipelineInput,
         [ValidateRange(0,2)]
         [decimal]$temperature = 0.0,
-        $max_tokens = 256
+        [int]$max_tokens = 25
     )
 
     Begin {
@@ -29,7 +30,7 @@ function ai {
     }
 
     Process {
-        $lines += $pipelineInput
+        $lines += "$pipelineInput"
     }
 
     End {

--- a/Public/ai.ps1
+++ b/Public/ai.ps1
@@ -22,7 +22,7 @@ function ai {
         [psobject[]]$pipelineInput,
         [ValidateRange(0,2)]
         [decimal]$temperature = 0.0,
-        [int]$max_tokens = 25
+        [int]$max_tokens = 256
     )
 
     Begin {


### PR DESCRIPTION
Now you can just do:

`ai when was justin bieber born?`

Also makes datatypes more strict, which I imagine helps with the ValueFromRemainingArguments

First one is before the change, then subsequent ones are after the change with diff param usage

![image](https://github.com/dfinke/PowerShellAI/assets/8278033/d9db47fa-742d-4d8f-983f-75a00c5eb0da)

![image](https://github.com/dfinke/PowerShellAI/assets/8278033/16e32057-f40c-4b52-8c38-035538d40b6c)


